### PR TITLE
Adds option to use sparse matrices to SislWrapper and SislDownfolder

### DIFF
--- a/banddownfolder/scdm/downfolder.py
+++ b/banddownfolder/scdm/downfolder.py
@@ -277,12 +277,18 @@ class SislDownfolder(BandDownfolder):
                  fdf_file=None,
                  H=None,
                  spin=None,
-                 recover_fermi=False):
+                 recover_fermi=False,
+                 format='dense',
+                 nbands=10):
         """
         Parameters:
         ========================================
         folder: folder of siesta calculation
         fdf_file: siesta input filename
+        format: matrix format used internally, can be 'dense' or 'sparse' 
+                (default: 'dense')
+        nbands: number of eigenvalues calculated during diagonalization, only
+                relevant if format='sparse' (default:10)
         """
         try:
             import sisl
@@ -299,7 +305,8 @@ class SislDownfolder(BandDownfolder):
                 self.efermi = fdf.read_fermi_level()
             if recover_fermi:
                 self.shift_fermi = self.efermi
-        self.model = SislWrapper(H, spin=spin, shift_fermi=shift_fermi)
+        self.model = SislWrapper(H, spin=spin, shift_fermi=shift_fermi,
+                                 format=format, nbands=nbands)
         self.atoms = self.model.atoms
         try:
             positions = self.model.positions


### PR DESCRIPTION
This pull request aims to add support for sparse matrices to the `SislWrapper`  and `SislDownfolder`.

For this purpose two new attributes are added to the `SislWrapper`: 
1. `format` : can be 'dense' or 'sparse' and defines whether which matrix format to use.
2. `nbands`: defines the number of eigenvalues calculated in the sparse algorithm for diagonalization.

For 'sparse' matrices we now call the `eigsh`  routine of the `sisl.physics.Hamiltonian` instead of `eigh`.

HeXu, I'd love to get your feedback on this. I haven't been able to test it yet but will do so and report back here soon.

Best, Nils